### PR TITLE
CocoaPods 1.1.0rc2 and Swift 2.3 migration

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,11 +1,11 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-target 'SimplePDF_Example', :exclusive => true do
+target 'SimplePDF_Example' do
   pod 'SimplePDFSwift', :path => '../'
 end
 
-target 'SimplePDF_Tests', :exclusive => true do
+target 'SimplePDF_Tests' do
   pod 'SimplePDFSwift', :path => '../'
 
   pod 'Quick', '~> 0.8'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Nimble (3.2.0)
   - Quick (0.9.2)
-  - SimplePDFSwift (0.1.1)
+  - SimplePDFSwift (0.2.0)
 
 DEPENDENCIES:
   - Nimble (~> 3.0)
@@ -10,11 +10,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   SimplePDFSwift:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Nimble: 703854335d181df169bbca9c97117b5cf8c47c1d
   Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
-  SimplePDFSwift: 84d95a9c555dc816c3563977112c89169fd0be6e
+  SimplePDFSwift: dddcf53006d378ef81c108c4eb69ef1ce9f15451
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 233295c8f995cbef672dffd83e8a6ff3ae968c68
+
+COCOAPODS: 1.1.0.rc.2

--- a/Example/SimplePDF.xcodeproj/project.pbxproj
+++ b/Example/SimplePDF.xcodeproj/project.pbxproj
@@ -213,14 +213,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -419,8 +421,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -464,8 +468,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -484,6 +490,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -492,12 +499,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 556099EE118477E831FBE9B4 /* Pods-SimplePDF_Example.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SimplePDF/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -505,12 +514,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A247239FC55D62CD18E5A79E /* Pods-SimplePDF_Example.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SimplePDF/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -518,6 +529,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B6B8A5EFE2A1705B3145BBAD /* Pods-SimplePDF_Tests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -527,6 +539,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -534,11 +547,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3B6DD16E263E3EA17BABFB57 /* Pods-SimplePDF_Tests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Example/SimplePDF.xcodeproj/project.pbxproj
+++ b/Example/SimplePDF.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0143B02A7600C097D646CCBC /* Pods_SimplePDF_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D27C11E0F83157C81BD71DD /* Pods_SimplePDF_Tests.framework */; };
+		04C45F3B30943FB63B203FC0 /* Pods_SimplePDF_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65AB1F9B3DF65A03567EDE17 /* Pods_SimplePDF_Example.framework */; };
 		57E4A0391CB6A0B000EBDFEF /* Demo.png in Resources */ = {isa = PBXBuildFile; fileRef = 57E4A0381CB6A0B000EBDFEF /* Demo.png */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -14,8 +16,6 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
-		A8F428F7AB6B0A4F2783F79D /* Pods_SimplePDF_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B0169053953C50202855388 /* Pods_SimplePDF_Example.framework */; };
-		F6EF04FAC2EC1E3ED8B1693D /* Pods_SimplePDF_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A14CEA4A2EA1824A89C8BCB6 /* Pods_SimplePDF_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,11 +29,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B0169053953C50202855388 /* Pods_SimplePDF_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SimplePDF_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0DCB57C4497CC1ABB166B7CA /* Pods-SimplePDF_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example.release.xcconfig"; sourceTree = "<group>"; };
 		1AC8B89E3D73A8D2544B9387 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		2D27C11E0F83157C81BD71DD /* Pods_SimplePDF_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SimplePDF_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B6DD16E263E3EA17BABFB57 /* Pods-SimplePDF_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		3BB44BCB67803C6A1698D498 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		4A4BE1F6B400BF6211ECBEC3 /* Pods-SimplePDF_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		556099EE118477E831FBE9B4 /* Pods-SimplePDF_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		57E4A0381CB6A0B000EBDFEF /* Demo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Demo.png; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* SimplePDF_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimplePDF_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -45,9 +45,9 @@
 		607FACE51AFB9204008FA782 /* SimplePDF_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplePDF_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
-		7BD232A005712A4E82F92522 /* Pods-SimplePDF_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		A14CEA4A2EA1824A89C8BCB6 /* Pods_SimplePDF_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SimplePDF_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A9B283E6D37BA62FBC5255C7 /* Pods-SimplePDF_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		65AB1F9B3DF65A03567EDE17 /* Pods_SimplePDF_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SimplePDF_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A247239FC55D62CD18E5A79E /* Pods-SimplePDF_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example.release.xcconfig"; sourceTree = "<group>"; };
+		B6B8A5EFE2A1705B3145BBAD /* Pods-SimplePDF_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplePDF_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		E3ACCBF4822A73427213F8A9 /* SimplePDFSwift.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SimplePDFSwift.podspec; path = ../SimplePDFSwift.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -56,7 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A8F428F7AB6B0A4F2783F79D /* Pods_SimplePDF_Example.framework in Frameworks */,
+				04C45F3B30943FB63B203FC0 /* Pods_SimplePDF_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,7 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F6EF04FAC2EC1E3ED8B1693D /* Pods_SimplePDF_Tests.framework in Frameworks */,
+				0143B02A7600C097D646CCBC /* Pods_SimplePDF_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,8 +78,8 @@
 				607FACD21AFB9204008FA782 /* Example for SimplePDF */,
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
-				E4ED40008625A518A1CF97D0 /* Pods */,
-				9CEFE948FD0F1118E63507E6 /* Frameworks */,
+				83C48FFABC027AD69AEFF061 /* Pods */,
+				CC6A42D3DBCBAE99EF595A9F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -142,24 +142,24 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
-		9CEFE948FD0F1118E63507E6 /* Frameworks */ = {
+		83C48FFABC027AD69AEFF061 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				0B0169053953C50202855388 /* Pods_SimplePDF_Example.framework */,
-				A14CEA4A2EA1824A89C8BCB6 /* Pods_SimplePDF_Tests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E4ED40008625A518A1CF97D0 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				4A4BE1F6B400BF6211ECBEC3 /* Pods-SimplePDF_Example.debug.xcconfig */,
-				0DCB57C4497CC1ABB166B7CA /* Pods-SimplePDF_Example.release.xcconfig */,
-				7BD232A005712A4E82F92522 /* Pods-SimplePDF_Tests.debug.xcconfig */,
-				A9B283E6D37BA62FBC5255C7 /* Pods-SimplePDF_Tests.release.xcconfig */,
+				556099EE118477E831FBE9B4 /* Pods-SimplePDF_Example.debug.xcconfig */,
+				A247239FC55D62CD18E5A79E /* Pods-SimplePDF_Example.release.xcconfig */,
+				B6B8A5EFE2A1705B3145BBAD /* Pods-SimplePDF_Tests.debug.xcconfig */,
+				3B6DD16E263E3EA17BABFB57 /* Pods-SimplePDF_Tests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		CC6A42D3DBCBAE99EF595A9F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				65AB1F9B3DF65A03567EDE17 /* Pods_SimplePDF_Example.framework */,
+				2D27C11E0F83157C81BD71DD /* Pods_SimplePDF_Tests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -169,12 +169,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "SimplePDF_Example" */;
 			buildPhases = (
-				87EB9B91651AB45651B143C3 /* Check Pods Manifest.lock */,
+				0A3536D44AD214B82749ECEE /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				20E9A967E9C2DC4F3A121450 /* Embed Pods Frameworks */,
-				4F1D76DCCFE5F438911F6679 /* Copy Pods Resources */,
+				D0DF7144DB5FDC745788A989 /* [CP] Embed Pods Frameworks */,
+				FD1327D06F1C03183BABF8FC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -189,12 +189,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "SimplePDF_Tests" */;
 			buildPhases = (
-				14B3343E7D850FDD3488ABBA /* Check Pods Manifest.lock */,
+				499BF249C06922FEA8315837 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
-				0E70B037BE47C297B5FFB56C /* Embed Pods Frameworks */,
-				57B5F6CDBB1698957F81DC74 /* Copy Pods Resources */,
+				96E1729B738B7A725CBE3BD0 /* [CP] Embed Pods Frameworks */,
+				9C7A30138ECC59DBB3D8BE83 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -266,14 +266,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0E70B037BE47C297B5FFB56C /* Embed Pods Frameworks */ = {
+		0A3536D44AD214B82749ECEE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		499BF249C06922FEA8315837 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		96E1729B738B7A725CBE3BD0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -281,59 +311,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		14B3343E7D850FDD3488ABBA /* Check Pods Manifest.lock */ = {
+		9C7A30138ECC59DBB3D8BE83 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		20E9A967E9C2DC4F3A121450 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4F1D76DCCFE5F438911F6679 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		57B5F6CDBB1698957F81DC74 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -341,19 +326,34 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Tests/Pods-SimplePDF_Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		87EB9B91651AB45651B143C3 /* Check Pods Manifest.lock */ = {
+		D0DF7144DB5FDC745788A989 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD1327D06F1C03183BABF8FC /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SimplePDF_Example/Pods-SimplePDF_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -490,7 +490,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A4BE1F6B400BF6211ECBEC3 /* Pods-SimplePDF_Example.debug.xcconfig */;
+			baseConfigurationReference = 556099EE118477E831FBE9B4 /* Pods-SimplePDF_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SimplePDF/Info.plist;
@@ -503,7 +503,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0DCB57C4497CC1ABB166B7CA /* Pods-SimplePDF_Example.release.xcconfig */;
+			baseConfigurationReference = A247239FC55D62CD18E5A79E /* Pods-SimplePDF_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SimplePDF/Info.plist;
@@ -516,7 +516,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BD232A005712A4E82F92522 /* Pods-SimplePDF_Tests.debug.xcconfig */;
+			baseConfigurationReference = B6B8A5EFE2A1705B3145BBAD /* Pods-SimplePDF_Tests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -532,7 +532,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A9B283E6D37BA62FBC5255C7 /* Pods-SimplePDF_Tests.release.xcconfig */;
+			baseConfigurationReference = 3B6DD16E263E3EA17BABFB57 /* Pods-SimplePDF_Tests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;

--- a/Example/SimplePDF.xcodeproj/xcshareddata/xcschemes/SimplePDF-Example.xcscheme
+++ b/Example/SimplePDF.xcodeproj/xcshareddata/xcschemes/SimplePDF-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Pod/Classes/SimplePDF.swift
+++ b/Pod/Classes/SimplePDF.swift
@@ -475,7 +475,10 @@ public class SimplePDF {
             var textRect = textRectIn
             textRect = convertRectToCoreTextCoordinates(textRect)
             
-            let context = UIGraphicsGetCurrentContext()
+            guard let context = UIGraphicsGetCurrentContext() else {
+                return
+            }
+            
             let bounds = getPageBounds()
             CGContextSetTextMatrix(context, CGAffineTransformIdentity)
             CGContextTranslateCTM(context, 0, bounds.size.height)
@@ -486,7 +489,7 @@ public class SimplePDF {
             CGPathAddRect(textPath, nil, textRect)
             let frameRef = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), textPath, nil)
             
-            CTFrameDraw(frameRef, context!)
+            CTFrameDraw(frameRef, context)
             
             // flip it back
             CGContextScaleCTM(context, 1.0, -1.0)
@@ -708,14 +711,17 @@ public class SimplePDF {
                         
                         if(calculationOnly == false) {
                             // flip context
-                            let context = UIGraphicsGetCurrentContext()
+                            guard let context = UIGraphicsGetCurrentContext() else {
+                                continue
+                            }
+                            
                             let bounds = UIGraphicsGetPDFContextBounds()
                             CGContextSetTextMatrix(context, CGAffineTransformIdentity)
                             CGContextTranslateCTM(context, bounds.origin.x, bounds.size.height)
                             CGContextScaleCTM(context, 1.0, -1.0)
                             
                             CGContextSetTextPosition(context, textPoint.x, textPoint.y)
-                            CTLineDraw(truncatedLine!, context!)
+                            CTLineDraw(truncatedLine!, context)
                             
                             // flip it back
                             CGContextScaleCTM(context, 1.0, -1.0)
@@ -895,7 +901,10 @@ public class SimplePDF {
                     
                     if(calculationOnly == false) {
                         // flip context
-                        let context = UIGraphicsGetCurrentContext()
+                        guard let context = UIGraphicsGetCurrentContext() else {
+                            continue
+                        }
+                        
                         let bounds = UIGraphicsGetPDFContextBounds()
                         CGContextSetTextMatrix(context, CGAffineTransformIdentity)
                         CGContextTranslateCTM(context, bounds.origin.x, bounds.size.height)
@@ -905,7 +914,7 @@ public class SimplePDF {
                         CGPathAddRect(textPath, nil, textRect)
                         let frameRef = CTFramesetterCreateFrame(thisFramesetter, thisRange, textPath, nil)
                         
-                        CTFrameDraw(frameRef, context!)
+                        CTFrameDraw(frameRef, context)
                         
                         // flip it back
                         CGContextScaleCTM(context, 1.0, -1.0)
@@ -971,8 +980,11 @@ public class SimplePDF {
             }
             
             if(calculationOnly == false) {
-                let context = UIGraphicsGetCurrentContext()
-                view.layer.renderInContext(context!)
+                guard let context = UIGraphicsGetCurrentContext() else {
+                    return range
+                }
+                
+                view.layer.renderInContext(context)
             }
             
             // one view per page, set Y to maximum so that next call inserts a page
@@ -1034,7 +1046,10 @@ public class SimplePDF {
         // MARK: - Drawing
         private func drawRect(rect: CGRect, fillColor fillColorIn: UIColor? = nil) {
             let fillColor = fillColorIn ?? UIColor(red: 0.95, green: 0.95, blue: 0.95, alpha: 1.0)
-            let context = UIGraphicsGetCurrentContext()
+            guard let context = UIGraphicsGetCurrentContext() else {
+                return
+            }
+            
             CGContextSetRGBStrokeColor(context, 0, 0, 0, 1)
             CGContextSetFillColorWithColor(context, fillColor.CGColor)
             CGContextFillRect(context, rect)
@@ -1046,11 +1061,14 @@ public class SimplePDF {
             if(color == nil) {
                 color = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
             }
-            let context = UIGraphicsGetCurrentContext()
-            CGContextSetStrokeColorWithColor(context, color!.CGColor);
-            CGContextSetLineWidth(context, strokeWidth);
-            CGContextMoveToPoint(context, p1.x, p1.y);
-            CGContextAddLineToPoint(context, p2.x, p2.y);
+            guard let context = UIGraphicsGetCurrentContext() else {
+                return
+            }
+            
+            CGContextSetStrokeColorWithColor(context, color!.CGColor)
+            CGContextSetLineWidth(context, strokeWidth)
+            CGContextMoveToPoint(context, p1.x, p1.y)
+            CGContextAddLineToPoint(context, p2.x, p2.y)
             CGContextDrawPath(context, CGPathDrawingMode.Stroke)
         }
         

--- a/Pod/Classes/SimplePDFLabel.swift
+++ b/Pod/Classes/SimplePDFLabel.swift
@@ -23,7 +23,7 @@ class SimplePDFLabel: UILabel {
         
         let isPDF = !CGRectIsEmpty(UIGraphicsGetPDFContextBounds())
         
-        if(!layer.shouldRasterize && isPDF && (self.backgroundColor == nil || CGColorGetAlpha(self.backgroundColor?.CGColor) == 0)) {
+        if(!layer.shouldRasterize && isPDF && (self.backgroundColor == nil || CGColorGetAlpha(self.backgroundColor!.CGColor) == 0)) {
             self.drawRect(self.bounds)
         }
         else {


### PR DESCRIPTION
1. :exclusive => true and link_with have been removed in CocoaPods 1.0. http://blog.cocoapods.org/CocoaPods-1.0-Migration-Guide/
2. UIGraphicsGetCurrentContext() returns optional CGContext after Swift 2.3 and we need to check its nullity.
